### PR TITLE
Billing address is not required for creating order

### DIFF
--- a/lib/worldpay.php
+++ b/lib/worldpay.php
@@ -171,7 +171,7 @@ final class Worldpay
         if (!isset($order['name'])) {
             $errors[] = self::$errors['orderInput']['name'];
         }
-        if (!isset($order['billingAddress'])) {
+        if (isset($order['billingAddress']) && !is_array($order['billingAddress'])) {
             $errors[] = self::$errors['orderInput']['billingAddress'];
         }
 


### PR DESCRIPTION
The commit is based on documentation:
https://online.worldpay.com/api#orders

The documentation says, that billingAddress is optional.
