### PR TITLE
Update Order.php

### DIFF
--- a/lib/Order.php
+++ b/lib/Order.php
@@ -43,7 +43,11 @@ class Order extends AbstractOrder
         }
 
         if ($this->is3DSOrder) {
-            $_SESSION['worldpay_sessionid'] = $order['shopperSessionId'];
+            if (isset($order['shopperSessionId']) && $order['shopperSessionId']) {
+                $_SESSION['worldpay_sessionid'] = $order['shopperSessionId'];
+            } else {
+                $_SESSION['worldpay_sessionid'] = uniqid();
+            }
             $threeDSShopper = Utils::getThreeDSShopperObject();
             $this->shopperIpAddress = $threeDSShopper['shopperIpAddress'];
             $this->shopperSessionId = $threeDSShopper['shopperSessionId'];

--- a/lib/Order.php
+++ b/lib/Order.php
@@ -43,7 +43,7 @@ class Order extends AbstractOrder
         }
 
         if ($this->is3DSOrder) {
-            $_SESSION['worldpay_sessionid'] = uniqid();
+            $_SESSION['worldpay_sessionid'] = $order['shopperSessionId'];
             $threeDSShopper = Utils::getThreeDSShopperObject();
             $this->shopperIpAddress = $threeDSShopper['shopperIpAddress'];
             $this->shopperSessionId = $threeDSShopper['shopperSessionId'];


### PR DESCRIPTION
When creating a 3D Secure order, an error was returned that the session id was not valid. I am unsure if there are any instances of the ShopperSessionId not being present in the $order array.
